### PR TITLE
Hotfix 2 for DMA Loopback

### DIFF
--- a/contrib/dma_loopback/hw/afu.sv
+++ b/contrib/dma_loopback/hw/afu.sv
@@ -140,7 +140,7 @@ module afu
        .rst_n(~rst),
        .host_init(go),
        .host_rd_ready(~dma.empty),
-       .host_wr_ready(~dma.full),
+       .host_wr_ready(~dma.full & ~dma.host_wr_completed),
        .op(mem_op), // CPU Defined
        .raw_address(cpu_addr), // Address in the CPU space
        .address_offset(wr_addr),

--- a/contrib/dma_loopback/hw/cci_dma.sv
+++ b/contrib/dma_loopback/hw/cci_dma.sv
@@ -243,6 +243,7 @@ module cci_dma
    // Assign DMA interface outputs.
    assign dma.rd_done = !reads_are_pending;
    assign dma.wr_done = !writes_are_pending;
+   assign dma.host_wr_completed = cci_wr_en_delayed || !c1Empty;
    assign dma.full    = c1TxAlmFull;
   
 endmodule

--- a/contrib/dma_loopback/hw/dma_if.vh
+++ b/contrib/dma_loopback/hw/dma_if.vh
@@ -98,6 +98,7 @@ interface dma_if #(parameter int DATA_WIDTH,
       output wr_addr,
       output wr_size,
       output wr_data,
+      output host_wr_completed,
       input  wr_done,
       input  full		       
       );

--- a/contrib/dma_loopback/hw/dma_if.vh
+++ b/contrib/dma_loopback/hw/dma_if.vh
@@ -46,7 +46,7 @@ interface dma_if #(parameter int DATA_WIDTH,
    typedef logic [ADDR_WIDTH-1:0] addr_t;
    typedef logic [SIZE_WIDTH-1:0] count_t;
 
-   logic rd_go, rd_done, rd_en, empty;
+   logic rd_go, rd_done, rd_en, empty, host_wr_completed;
    logic [DATA_WIDTH-1:0] rd_data;
    addr_t rd_addr;
    count_t rd_size;
@@ -77,6 +77,7 @@ interface dma_if #(parameter int DATA_WIDTH,
       input  wr_addr,
       input  wr_size,
       input  wr_data,
+      output host_wr_completed,
       output wr_done,
       output full				
       );

--- a/rtl/mem_ctrl.sv
+++ b/rtl/mem_ctrl.sv
@@ -202,7 +202,7 @@ module mem_ctrl
 						line_buffer <= host_data_bus_read_in;
 						state <= FILL;
 					end
-					else if(op == WRITE && host_wr_ready && bubble) begin
+					else if(op == WRITE && bubble) begin
 						// Write
 						/* Here, we should just write the data and then
 						 * return to READY when done
@@ -210,7 +210,7 @@ module mem_ctrl
 						state <= READY;
 						bubble <= 1'b0;
 					end
-					else if(op == WRITE && !bubble) begin
+					else if(op == WRITE && !bubble && host_wr_ready) begin
 						// Wait a cycle to let any address changes propagate down the chain.
 						bubble <= bubble + 1;
 					end

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -62,6 +62,8 @@ namespace priscas
 
 	const std::string HELP_MEM =	std::string(".mem\n") +
 									std::string("Usage: .mem [-a OR -h] range_0... range_1...\n") +
+									std::string("-h: use hex value output with hex indexing\n") +
+									std::string("-a: use ascii value output with hex indexing\n") +
 									std::string("With no args, .mem will only print out the size of main memory\n") +
 									std::string("However a single memory address can be printed with a single unsigned integer argument:\n") +
 									std::string(".mem 0 # print mem[0]\n") +

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -61,6 +61,7 @@ namespace priscas
 									std::string("For more information, just use .help without specifying any arguments.\n");
 
 	const std::string HELP_MEM =	std::string(".mem\n") +
+									std::string("Usage: .mem [-a OR -h] range_0... range_1...\n") +
 									std::string("With no args, .mem will only print out the size of main memory\n") +
 									std::string("However a single memory address can be printed with a single unsigned integer argument:\n") +
 									std::string(".mem 0 # print mem[0]\n") +

--- a/src/runtime_call.cpp
+++ b/src/runtime_call.cpp
@@ -352,9 +352,16 @@ namespace priscas
 
 		size_t first = 1;
 		bool hexOutput = false;
+		bool asciiOutput = false;
 		if(args[1] == "-h")
 		{
 			hexOutput = true;
+			first++;
+		}
+
+		if(args[1] == "-a")
+		{
+			asciiOutput = true;
 			first++;
 		}
 
@@ -371,7 +378,8 @@ namespace priscas
 				}
 
 				UPString index_str = hexOutput ? genericHexBuilder<uint32_t, 32>(*itr_2) :  priscas_io::StrTypes::SizeToStr(*itr_2);
-				UPString val_str = hexOutput ? genericHexBuilder<uint8_t, 8>(inst.Mem()[*itr_2]) : priscas_io::StrTypes::IntToStr(inst.Mem()[*itr_2]);
+				UPString val_str = hexOutput ? genericHexBuilder<uint8_t, 8>(inst.Mem()[*itr_2]) :
+							asciiOutput ? UPString("\'") + (UPString += inst.Mem()[*itr_2]) +  UPString("\'") : priscas_io::StrTypes::IntToStr(inst.Mem()[*itr_2]);
 
 				std::string o = (std::string("Mem[") + index_str + std::string("]: ") + 
 					val_str + priscas_io::newLine);

--- a/src/runtime_call.cpp
+++ b/src/runtime_call.cpp
@@ -379,7 +379,7 @@ namespace priscas
 
 				UPString index_str = hexOutput ? genericHexBuilder<uint32_t, 32>(*itr_2) :  priscas_io::StrTypes::SizeToStr(*itr_2);
 				UPString val_str = hexOutput ? genericHexBuilder<uint8_t, 8>(inst.Mem()[*itr_2]) :
-							asciiOutput ? UPString("\'") + (UPString += inst.Mem()[*itr_2]) +  UPString("\'") : priscas_io::StrTypes::IntToStr(inst.Mem()[*itr_2]);
+							asciiOutput ? UPString("\'") + (UPString() + inst.Mem()[*itr_2]) +  UPString("\'") : priscas_io::StrTypes::IntToStr(inst.Mem()[*itr_2]);
 
 				std::string o = (std::string("Mem[") + index_str + std::string("]: ") + 
 					val_str + priscas_io::newLine);

--- a/src/runtime_call.cpp
+++ b/src/runtime_call.cpp
@@ -379,7 +379,7 @@ namespace priscas
 
 				UPString index_str = hexOutput ? genericHexBuilder<uint32_t, 32>(*itr_2) :  priscas_io::StrTypes::SizeToStr(*itr_2);
 				UPString val_str = hexOutput ? genericHexBuilder<uint8_t, 8>(inst.Mem()[*itr_2]) :
-							asciiOutput ? UPString("\'") + (UPString() + inst.Mem()[*itr_2]) +  UPString("\'") : priscas_io::StrTypes::IntToStr(inst.Mem()[*itr_2]);
+							asciiOutput ? UPString("\'") + (UPString() + static_cast<char>(inst.Mem()[*itr_2])) +  UPString("\'") : priscas_io::StrTypes::IntToStr(inst.Mem()[*itr_2]);
 
 				std::string o = (std::string("Mem[") + index_str + std::string("]: ") + 
 					val_str + priscas_io::newLine);

--- a/src/runtime_call.cpp
+++ b/src/runtime_call.cpp
@@ -377,7 +377,7 @@ namespace priscas
 					throw priscas::mem_oob_exception();
 				}
 
-				UPString index_str = hexOutput ? genericHexBuilder<uint32_t, 32>(*itr_2) :  priscas_io::StrTypes::SizeToStr(*itr_2);
+				UPString index_str = hexOutput || asciiOutput ? genericHexBuilder<uint32_t, 32>(*itr_2) :  priscas_io::StrTypes::SizeToStr(*itr_2);
 				UPString val_str = hexOutput ? genericHexBuilder<uint8_t, 8>(inst.Mem()[*itr_2]) :
 							asciiOutput ? UPString("\'") + (UPString() + static_cast<char>(inst.Mem()[*itr_2])) +  UPString("\'") : priscas_io::StrTypes::IntToStr(inst.Mem()[*itr_2]);
 


### PR DESCRIPTION
This issue fixes an issue with DMA loopback skipping over writes. Please merge these changes into your repository as quick as possible. These can be important for consistent and deterministic behavior on your demos. If this fix is not complete (i.e. does not fix the issue completely) please report any bugs directly and immediately to me.

**Why is this needed?**
Previously ~fill was checked for detecting if the host DMA can get another write pushed in. Another signal was needed to capture the actual latency of the machine *not* just including the buffer "fullness". Performing quick enough writes would lead to packet loss in ones following the first.

**Applying this Hotfix**
Unless you are a user of the 512-bit bus interface (TEAM 2 or TEAM 4) (see below for the difference), merge all files except for afu.sv manually or **making a backup of afu.sv** using `git pull`, and then reapplying your working afu.sv with the following below.

You ALSO need to do one more thing:

In your instantiation of mem_ctrl, tie host_wr_ready to (~dma.full & ~dma.host_wr_completed) instead of just (~dma.full).

NOTE TO 512-bit bus users (a.k.a Team 2 and Team 4): I will be posting a revised copy of **mem_ctrl.sv** to your Teams channels based on your shared code base. You still need the same interface updates to the DMA so merge everything **except** the new mem_ctrl.sv and afu.sv.

Thank you all for your patience and sorry for the inconvenience.